### PR TITLE
Determine column data type by all cells in given column

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "watch": "babel -w src --out-dir .",
         "prepublish": "npm run prettify && cross-env NODE_ENV=production npm run build",
         "prettify": "prettier ./src/** --write",
-        "test": "jest"
+        "test": "jest src/__test__"
     },
     "author": "Brandon Paquette <brandon@brandon.sh>",
     "keywords": [
@@ -17,6 +17,9 @@
         "gatsby-source-plugin"
     ],
     "license": "MIT",
+    "jest": {
+        "testEnvironment": "node"
+    },
     "dependencies": {
         "flow-bin": "^0.56.0",
         "google-spreadsheet": "2.0.3",

--- a/src/__test__/fetch-sheet.test.js
+++ b/src/__test__/fetch-sheet.test.js
@@ -1,4 +1,4 @@
-const { cleanRows } = require("../fetch-sheet.js");
+const { cleanRows, guessColumnsDataTypes } = require("../fetch-sheet.js");
 
 describe("cleaning rows from GSheets response", () => {
   it("removes keys that don't correspond to column names", () => {
@@ -31,9 +31,84 @@ describe("cleaning rows from GSheets response", () => {
     const cleaned = cleanRows([emojiRow])[0];
     expect(cleaned.emoji).toEqual(TEST_EMOJI_STRING);
   });
+  
   it("returns comma-delineated number strings as numbers", () => {
     const numRow = { short: "1", long: "123,456,789", decimal: "0.5912", mixed: "123,456.789" };
     const cleaned = cleanRows([numRow])[0];
     expect(Object.values(cleaned)).toEqual([1, 123456789, 0.5912, 123456.789]);
   });
+
+  it('parses cells as numbers when all column cells contains numbers only', function () {
+    const rows = [
+      { column: "5" },
+      { column: "2" }
+    ];
+    const cleaned = cleanRows(rows);
+    expect(cleaned[0].column).toBe(5);
+    expect(cleaned[1].column).toBe(2);
+  });
+
+  it('parses all cells in column as strings when data types are mixed in given column', function () {
+    const rows = [
+      { column: "5"},
+      { column: "hello" }
+    ];
+    const cleaned = cleanRows(rows);
+    expect(cleaned[0].column).toBe("5");
+    expect(cleaned[1].column).toBe("hello");
+  });
+
+  it('guesses column types', function () {
+    const rows = [
+      { number: "0", string: "something", null: null, boolean: "TRUE" },
+      { number: "1", string: "anything", null: null, boolean: "FALSE" },
+      { number: "2", string: "nothing", null: null, boolean: null }
+    ];
+    const cleaned = cleanRows(rows);
+    expect(cleaned.map(row => row.number)).toEqual([0,1,2]);
+    expect(cleaned.map(row => row.string)).toEqual(["something", "anything", "nothing"]);
+    expect(cleaned.map(row => row.null)).toEqual([null, null, null]);
+    expect(cleaned.map(row => row.boolean)).toEqual([true, false, null]);
+  });
+});
+
+describe("guessing column data type based on all cells in column", () => {
+  it('recognizes type for all same cells', function () {
+    const rows = [
+      { numbers: "1,", strings: "something", nulls: null, booleans: "TRUE" },
+      { numbers: "2", strings: "anything", nulls: null, booleans: "FALSE" },
+      { numbers: "3,", strings: "nothing", nulls: null, booleans: "TRUE" }
+    ];
+    const guessedTypes = guessColumnsDataTypes(rows);
+    expect(guessedTypes.numbers).toBe('number');
+    expect(guessedTypes.strings).toBe('string');
+    expect(guessedTypes.nulls).toBeUndefined();
+    expect(guessedTypes.booleans).toBe('boolean');
+  });
+  
+  it('ignores null', function () {
+    const rows = [
+      { numbers: "1,", strings: "something", nulls: null, booleans: null },
+      { numbers: null, strings: "anything", nulls: null, booleans: "FALSE" },
+      { numbers: "3,", strings: null, nulls: null, booleans: "TRUE" }
+    ];
+    const guessedTypes = guessColumnsDataTypes(rows);
+    expect(guessedTypes.numbers).toBe('number');
+    expect(guessedTypes.strings).toBe('string');
+    expect(guessedTypes.nulls).toBeUndefined();
+    expect(guessedTypes.booleans).toBe('boolean');
+  });
+
+  it('fallbacks to string when types are different', function () {
+    const rows = [
+      { numbers: "1,", strings: "something", nulls: null, booleans: "TRUE" },
+      { numbers: "2", strings: "anything", nulls: null, booleans: "FALSE" },
+      { numbers: "3/5,", strings: "nothing", nulls: null, booleans: "TRUE" }
+    ];
+    const guessedTypes = guessColumnsDataTypes(rows);
+    expect(guessedTypes.numbers).toBe('string');
+    expect(guessedTypes.strings).toBe('string');
+    expect(guessedTypes.nulls).toBeUndefined();
+    expect(guessedTypes.booleans).toBe('boolean');
+  });  
 });

--- a/src/fetch-sheet.js
+++ b/src/fetch-sheet.js
@@ -33,23 +33,62 @@ const getRows = (worksheet, options = {}) =>
     })
   );
 
-const cleanRows = rows =>
-  rows.map(r =>
+const cleanRows = rows => {
+  const columnTypes = guessColumnsDataTypes(rows);
+  return rows.map(r =>
+    _.chain(r)
+      .omit(["_xml", "app:edited", "save", "del", "_links"])
+      .mapKeys((v, k) => _.camelCase(k))
+      .mapValues((val, key) => {
+        switch (columnTypes[key]) {
+          case "number":
+            return Number(val.replace(/,/g, ""));
+          case "boolean":
+            // when column contains null we return null, otherwise check boolean value
+            return val === null ? null : val === "TRUE";
+          default:
+            return val;
+        }
+      })
+      .value()
+  );
+};
+
+const guessColumnsDataTypes = rows =>
+  _.flatMap(rows, r =>
     _.chain(r)
       .omit(["_xml", "app:edited", "save", "del", "_links"])
       .mapKeys((v, k) => _.camelCase(k))
       .mapValues(val => {
-        if (val === "") return null;
-        // sheets apparently leaves commas in some #s depending on formatting
-        if (val.replace(/[,\.\d]/g, "").length === 0 && val !== "") {
-          return Number(val.replace(/,/g, ""));
+        // try to determine type based on the cell value
+        if (!val) {
+          return "null";
+        } else if (val.replace(/[,\.\d]/g, "").length === 0) {
+          // sheets apparently leaves commas in some #s depending on formatting
+          return "number";
+        } else if (val === "TRUE" || val === "FALSE") {
+          return "boolean";
+        } else {
+          return "string";
         }
-        if (val === "TRUE") return true;
-        if (val === "FALSE") return false;
-        return val;
       })
       .value()
-  );
+  ).reduce((columnTypes, row) => {
+    _.forEach(row, (type, columnName) => {
+      // skip nulls, they should have no effect
+      if (type === 'null') { return; }
+      
+      const currentTypeCandidate = columnTypes[columnName];
+      if (!currentTypeCandidate) {
+        // no discovered type yet -> use the one from current item
+        columnTypes[columnName] = type;
+      } else if (currentTypeCandidate !== type) {
+        // previously discovered type is different therefore we fallback to string
+        columnTypes[columnName] = "string";
+      }
+    });
+    return columnTypes;
+  }, {})
 
 const fetchData = async (spreadsheetId, worksheetTitle, credentials) => {
   const spreadsheet = await getSpreadsheet(spreadsheetId, credentials);
@@ -58,5 +97,5 @@ const fetchData = async (spreadsheetId, worksheetTitle, credentials) => {
   return cleanRows(rows);
 };
 
-export { cleanRows };
+export { cleanRows, guessColumnsDataTypes };
 export default fetchData;


### PR DESCRIPTION
This solves issue https://github.com/brandonmp/gatsby-source-google-sheets/issues/18 with inconsistent data types with mixed data.

Solution:
1. First it goes through all data and tries to define a data type for each column.
1. After it goes through all data types and it parses values based on data type from the previous step.