### PR TITLE
Update google-spreadsheet package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "flow-bin": "^0.56.0",
-        "google-spreadsheet": "2.0.3",
+        "google-spreadsheet": "^2.0.7",
         "lodash": "^4.17.4",
         "uuid": "^3.1.0"
     },


### PR DESCRIPTION
Version 2.0.3 is very old by now, and this should also resolve warnings in #25. Testing is obviously needed.

Thanks for this plugin!